### PR TITLE
return not implemented if accessing dynamic index

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Use 55:BC:29:4B:BA:B6:A1:03:42:A9:D8:51:14:9D:BD:00:D2:2A:9C:A1:B8:4A:85:E1:AF:B
 
 Use apikey@pbs for username, s3 secret as password , and bucket as datastore 
 
+Does currently only work for pbs VM backups, not with proxmox-backup-client

--- a/main.go
+++ b/main.go
@@ -223,11 +223,17 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	C := TicketEntry{}
 	if len(matches) >= 2 {
-
 		C, auth = s.Auth[matches[1]]
 	}
 
 	path := strings.Split(r.RequestURI, "/")
+
+	if strings.HasPrefix(r.RequestURI, "/dynamic") && s.H2Ticket != nil && r.Method == "POST" {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("not implemented"))
+		return
+	}
+
 	if len(path) >= 7 && strings.HasPrefix(r.RequestURI, "/api2/json/admin/datastore/") && auth {
 		ds := path[5]
 		action := path[6]


### PR DESCRIPTION
wasted some time trying with proxmox-backup-client, which uses dynamic instead of fixed indexes and bails with an cryptic error message if the endpoint isnt emplemented:

```
Upload directory '/tmp/test' to 'uWXkDzPGrDVFaPkOR96m@pbs@localhost:8007:test' as root2.pxar.didx
thread 'tokio-runtime-worker' panicked at /usr/share/cargo/registry/proxmox-backup-3.2.7/pbs-client/src/backup_writer.rs:334:14:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at /usr/share/cargo/registry/proxmox-backup-3.2.7/pbs-client/src/backup_writer.rs:334:14:
called `Option::unwrap()` on a `None` value
```

now it ends with an according error at least..

```
Starting backup protocol: Sun Jul 28 22:08:51 2024
No previous manifest available.
Upload directory '/tmp/test' to 'uWXkDzPGrDVFaPkOR96m@pbs@localhost:8007:test' as root2.pxar.didx
catalog upload error - not implemented
Error: stream closed because of a broken pipe
```

add note to README