### PR TITLE
feat: support containerization + add release workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
+# Ignore all files which are not go type
+!**/*.go
+!**/*.mod
+!**/*.sum

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - uses: goreleaser/goreleaser-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: latest
+          args: release
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,29 @@
+builds:
+  -
+    main: .
+    binary: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    no_unique_dist_dir: true
+
+archives:
+  -
+    id: tar
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  algorithm: sha256
+
+gomod:
+  proxy: false
+
+release:
+  draft: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM golang:1.22 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY . .
+
+# Build
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o pmoxs3backuproxy
+
+# Use chainguard static image as a minimal base
+# Refer to https://images.chainguard.dev/directory/image/static/versions for more details
+FROM cgr.dev/chainguard/static:latest
+
+WORKDIR /
+
+COPY --from=builder /workspace/pmoxs3backuproxy .
+
+COPY server.crt /
+COPY server.key /
+
+USER 65532:65532
+
+EXPOSE 8007
+
+ENTRYPOINT ["/pmoxs3backuproxy"]


### PR DESCRIPTION
This is also a bit of a counterproposal to #10

- uses goreleaser for creating the release with changelog and standalone binaries
- uses docker buildx for creating a minimal, multi-arch container image

The result can be reviewed here:
- https://github.com/gitgrave/pmoxs3backuproxy/releases/tag/v0.1.0-alpha.1
- https://github.com/gitgrave/pmoxs3backuproxy/pkgs/container/pmoxs3backuproxy

To trigger a release, all that's required is pushing a tag in the form of `v1.2.3`.

Since people are also running Proxmox on arm64 hardware and/or might want to host this proxy on something like a RPi or similar, both releases and container images are directly multi-arch.

```
$ docker run ghcr.io/gitgrave/pmoxs3backuproxy:latest -endpoint example.com:443 -debug
2024/07/31 06:17:21 [INFO]Starting PBS api server on 127.0.0.1:8007 , upstream: example.com:443
```