### PR TITLE
Make protection and remove button work

### DIFF
--- a/cmd/garbagecollector/main.go
+++ b/cmd/garbagecollector/main.go
@@ -86,6 +86,14 @@ func main() {
 
 	for _, s := range snapshots {
 		if s.BackupTime+(uint64(*retentionDays))*86400 < uint64(time.Now().Unix()) {
+			if s.Protected == true {
+				s3backuplog.DebugPrint("Backup %s/%d is older than %d but marked as protected, skip removal.",
+					s.BackupID,
+					s.BackupTime,
+					*retentionDays,
+				)
+				continue
+			}
 			s3backuplog.DebugPrint("Backup %s/%d is older than %d days, deleting", s.BackupID, s.BackupTime, *retentionDays)
 			s.Delete()
 		} else {

--- a/cmd/pmoxs3backuproxy/main.go
+++ b/cmd/pmoxs3backuproxy/main.go
@@ -145,9 +145,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		if strings.HasPrefix(action, "protected") && r.Method == "PUT" {
 			var ss s3pmoxcommon.Snapshot
-			ss.BackupID = r.FormValue("backup-id")
-			ss.BackupTime, _ = strconv.ParseUint(r.FormValue("backup-time"), 10, 64)
-			ss.BackupType = r.FormValue("backup-type")
+			ss.InitWithForm(r)
 
 			existingTags, err := C.Client.GetObjectTagging(
 				context.Background(),

--- a/cmd/pmoxs3backuproxy/main.go
+++ b/cmd/pmoxs3backuproxy/main.go
@@ -468,7 +468,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		)
 		if e != nil {
 			errResponse := minio.ToErrorResponse(e)
-			s3backuplog.ErrorPrint("Error getting object %s failed:", e.Error())
 			if errResponse.Code == "NoSuchKey" {
 				_, err := s.H2Ticket.Client.PutObject(
 					context.Background(),
@@ -479,7 +478,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					minio.PutObjectOptions{},
 				)
 				if err != nil {
-					s3backuplog.ErrorPrint("Writing object %s failed:", digest, err.Error())
+					s3backuplog.ErrorPrint("Writing object %s failed: %s", digest, err.Error())
 					w.WriteHeader(http.StatusInternalServerError)
 					w.Write([]byte(err.Error()))
 				}

--- a/internal/s3pmoxcommon/s3pmoxcommon.go
+++ b/internal/s3pmoxcommon/s3pmoxcommon.go
@@ -50,8 +50,8 @@ func ListSnapshots(c minio.Client, datastore string, returnCorrupted bool) ([]Sn
 				BackupTime: backuptimei,
 				BackupType: backuptype,
 				Files:      make([]SnapshotFile, 0),
-				c:          &c,
-				datastore:  datastore,
+				C:          &c,
+				Datastore:  datastore,
 				corrupted:  false,
 			}
 
@@ -102,14 +102,14 @@ func (S *Snapshot) Delete() error {
 		defer close(objectsCh)
 		// List all objects from a bucket-name with a matching prefix.
 		opts := minio.ListObjectsOptions{Prefix: S.S3Prefix(), Recursive: true}
-		for object := range S.c.ListObjects(context.Background(), S.datastore, opts) {
+		for object := range S.C.ListObjects(context.Background(), S.Datastore, opts) {
 			if object.Err != nil {
 				s3backuplog.ErrorPrint(object.Err.Error())
 			}
 			objectsCh <- object
 		}
 	}()
-	errorCh := S.c.RemoveObjects(context.Background(), S.datastore, objectsCh, minio.RemoveObjectsOptions{})
+	errorCh := S.C.RemoveObjects(context.Background(), S.Datastore, objectsCh, minio.RemoveObjectsOptions{})
 	for e := range errorCh {
 		s3backuplog.ErrorPrint("Failed to remove " + e.ObjectName + ", error: " + e.Err.Error())
 		return e.Err

--- a/internal/s3pmoxcommon/s3pmoxcommon.go
+++ b/internal/s3pmoxcommon/s3pmoxcommon.go
@@ -3,6 +3,7 @@ package s3pmoxcommon
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -83,6 +84,12 @@ func (S *Snapshot) InitWithQuery(v url.Values) {
 	S.BackupID = v.Get("backup-id")
 	S.BackupTime, _ = strconv.ParseUint(v.Get("backup-time"), 10, 64)
 	S.BackupType = v.Get("backup-type")
+}
+
+func (S *Snapshot) InitWithForm(r *http.Request) {
+	S.BackupID = r.FormValue("backup-id")
+	S.BackupTime, _ = strconv.ParseUint(r.FormValue("backup-time"), 10, 64)
+	S.BackupType = r.FormValue("backup-type")
 }
 
 func (S *Snapshot) S3Prefix() string {

--- a/internal/s3pmoxcommon/types.go
+++ b/internal/s3pmoxcommon/types.go
@@ -14,7 +14,7 @@ type Snapshot struct {
 	BackupType string         `json:"backup-type"` // vm , ct, host
 	Files      []SnapshotFile `json:"files"`
 	Protected  bool           `json:"protected"`
-	c          *minio.Client
-	datastore  string
+	C          *minio.Client
+	Datastore  string
 	corrupted  bool
 }


### PR DESCRIPTION
This simple implementation makes the "Change protection" Button in the PVE Backup view work.

A  simple approach is to set a "protected" Tag onto the snapshotfolder/index.json.blob.
If the tag is true = mark snapshot as protected, false = not protected.

A more sophisticated way would probably be to use S3 Object Lock mechanism, but i havent used them with
minio (i think they require a special minio setup with striping? At least thats what ive seen last time i was using this feature with minio, also, stuff is quite complicated with different retention modes etc..)

Further work would be to:

1) make code more reusable
2) GC should ignore protected snapshots if it removes them? (i havent had a look at the GC stuff ye and idk how the official PBS works with protected ones)

![protection](https://github.com/user-attachments/assets/fd41669d-8782-4b02-8823-dc28604f91ac)
