### PR TITLE
add microseconds to log output if debug option is enabled

### DIFF
--- a/internal/s3backuplog/s3backuplog.go
+++ b/internal/s3backuplog/s3backuplog.go
@@ -11,6 +11,7 @@ var Gdebug = false
 
 func EnableDebug() {
 	Gdebug = true
+	log.SetFlags(log.Ldate | log.Lmicroseconds)
 }
 
 func DebugPrint(fmt string, args ...interface{}) {


### PR DESCRIPTION
useful for detecting race issues