### PR TITLE
check access early

### DIFF
--- a/cmd/pmoxs3backuproxy/main.go
+++ b/cmd/pmoxs3backuproxy/main.go
@@ -872,6 +872,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		_, err := connectionList[username].ListBuckets(context.Background())
 		if err != nil {
+			delete(connectionList, username)
 			w.WriteHeader(http.StatusForbidden)
 			s3backuplog.ErrorPrint("Failed to list buckets: %s", err.Error())
 			w.Write([]byte(err.Error()))


### PR DESCRIPTION
it shouldbe checked ealier if the proxy has access to the s3 backend with the configured credentials.

before it would spawn the Serving service and route request through and then fail later on, thats not really nice.
Now it checks the Access using the ListBucket function right after setting up the minio connection (i think thats the way to "how to check access" with the async lib if you dont know the bucket at this time).

The client will fail early:

```
sudo -E proxmox-backup-client benchmark --repository SBQMMH19KWC0L521X6D@pbs@127.0.0.1:backups
Error: The Access Key Id you provided does not exist in our records.
```

before it was possible to get a speedtest through even if the credentials were wrong (potentially DoS'ing the service)

```
sudo -E proxmox-backup-client benchmark --repository SBQMMH19KWC0L521X6D@pbs@127.0.0.1:backups
Uploaded 1597 chunks in 5 seconds.
```

add handling for the speedtest URI too, even tho it doesnt make an difference.
