### PR TITLE
add remote sync support

### DIFF
--- a/.github/workflows/ci-dynamic.yml
+++ b/.github/workflows/ci-dynamic.yml
@@ -70,5 +70,8 @@ jobs:
           proxmox-backup-client snapshot protected show "$VER" | grep -q false
           proxmox-backup-client snapshot protected update "$VER" true
           proxmox-backup-client snapshot protected show "$VER" | grep -q true
+          proxmox-backup-client snapshot protected update "$VER" false
           echo "run GC"
           ./garbagecollector -endpoint $ENDPOINT -accesskey "$USERNAME" -secretkey "$PBS_PASSWORD" -bucket backups
+          echo "forget snapshot"
+          proxmox-backup-client snapshot forget "$VER"

--- a/cmd/garbagecollector/main.go
+++ b/cmd/garbagecollector/main.go
@@ -100,7 +100,7 @@ func main() {
 				continue
 			}
 			s3backuplog.InfoPrint("Backup %s is older than %d days, deleting", s.S3Prefix(), *retentionDays)
-			s.Delete()
+			s.Delete(*minioClient)
 		} else {
 			s3backuplog.InfoPrint("Backup %s is newer than %d days, keeping", s.S3Prefix(), *retentionDays)
 		}

--- a/cmd/pmoxs3backuproxy/http2.go
+++ b/cmd/pmoxs3backuproxy/http2.go
@@ -48,8 +48,7 @@ func (s *Server) backup(sock net.Conn, C TicketEntry, ds string, S s3pmoxcommon.
 	srv.ServeConn(sock, &http2.ServeConnOpts{Handler: snew})
 	if !snew.Finished { //Incomplete backup because connection died pve side, remove from S3
 		S.Datastore = ds
-		S.C = C.Client
-		if err := S.Delete(); err != nil {
+		if err := S.Delete(*C.Client); err != nil {
 			s3backuplog.ErrorPrint("Failed to remove incomplete backup: " + err.Error())
 		} else {
 			s3backuplog.WarnPrint("Removed incomplete backup %s", snew.Snapshot.S3Prefix())

--- a/cmd/pmoxs3backuproxy/types.go
+++ b/cmd/pmoxs3backuproxy/types.go
@@ -58,9 +58,25 @@ type Server struct {
 }
 
 type DataStoreStatus struct {
-	Avail int64 `json:"avail"`
-	Total int64 `json:"total"`
-	Used  int64 `json:"used"`
+	Avail   int64 `json:"avail"`
+	Total   int64 `json:"total"`
+	Used    int64 `json:"used"`
+	Counts  int64 `json:"counts"`
+	GCState bool  `json:"gc-status"`
+}
+
+type Namespace struct {
+	Name    string `json:"ns"`
+	Comment string `json:"comment"`
+}
+
+type Group struct {
+	Count      uint64   `json:"backup-count"`
+	BackupID   string   `json:"backup-id"`
+	BackupType string   `json:"backup-type"`
+	Files      []string `json:"files"`
+	BackupTime uint64   `json:"last-backup"`
+	Size       uint64   `json:"size"`
 }
 
 type AssignmentRequest struct {

--- a/internal/s3pmoxcommon/s3pmoxcommon.go
+++ b/internal/s3pmoxcommon/s3pmoxcommon.go
@@ -30,6 +30,12 @@ func ListSnapshots(c minio.Client, datastore string, returnCorrupted bool) ([]Sn
 			existing_S, ok := prefixMap[path[1]]
 			if ok {
 				if len(path) == 3 {
+					/** Dont add the custom chunk index list
+					 * for dynamic backup to filelist
+					 **/
+					if strings.HasSuffix(path[2], ".csjson") {
+						continue
+					}
 					if object.UserTags["protected"] == "true" {
 						existing_S.Protected = true
 					}
@@ -55,7 +61,6 @@ func ListSnapshots(c minio.Client, datastore string, returnCorrupted bool) ([]Sn
 				BackupTime: backuptimei,
 				BackupType: backuptype,
 				Files:      make([]SnapshotFile, 0),
-				C:          &c,
 				Datastore:  datastore,
 				corrupted:  false,
 			}
@@ -150,20 +155,20 @@ func (S *Snapshot) ReadTags(c minio.Client) (map[string]string, error) {
 	return existingTags.ToMap(), nil
 }
 
-func (S *Snapshot) Delete() error {
+func (S *Snapshot) Delete(c minio.Client) error {
 	objectsCh := make(chan minio.ObjectInfo)
 	go func() {
 		defer close(objectsCh)
 		// List all objects from a bucket-name with a matching prefix.
 		opts := minio.ListObjectsOptions{Prefix: S.S3Prefix(), Recursive: true}
-		for object := range S.C.ListObjects(context.Background(), S.Datastore, opts) {
+		for object := range c.ListObjects(context.Background(), S.Datastore, opts) {
 			if object.Err != nil {
 				s3backuplog.ErrorPrint(object.Err.Error())
 			}
 			objectsCh <- object
 		}
 	}()
-	errorCh := S.C.RemoveObjects(context.Background(), S.Datastore, objectsCh, minio.RemoveObjectsOptions{})
+	errorCh := c.RemoveObjects(context.Background(), S.Datastore, objectsCh, minio.RemoveObjectsOptions{})
 	for e := range errorCh {
 		s3backuplog.ErrorPrint("Failed to remove " + e.ObjectName + ", error: " + e.Err.Error())
 		return e.Err

--- a/internal/s3pmoxcommon/types.go
+++ b/internal/s3pmoxcommon/types.go
@@ -1,7 +1,5 @@
 package s3pmoxcommon
 
-import "github.com/minio/minio-go/v7"
-
 var PROXMOX_INDEX_MAGIC_DYNAMIC = [8]byte{28, 145, 78, 165, 25, 186, 179, 205}
 var PROXMOX_INDEX_MAGIC_STATIC = [8]byte{47, 127, 65, 237, 145, 253, 15, 205}
 
@@ -18,7 +16,7 @@ type Snapshot struct {
 	Files      []SnapshotFile `json:"files"`
 	Protected  bool           `json:"protected"`
 	Comment    string         `json:"comment"` // first line of notes
-	C          *minio.Client
 	Datastore  string
 	corrupted  bool
+	Size       uint64 `json:"size"`
 }


### PR DESCRIPTION
First draft to implement some endpoints required for syncing an remote S3 to a local PBS instance.
This is how it goes:

1) configure S3 storage in PVE (name "s3store" and schedule some backups)
2) configure the same S3 storage in an PBS instance (fresh install, or existing install) as "remote" with s3store as name

3) Create a new datastore:

` proxmox-backup-manager datastore create test2 /tmp/syncme`

4) Start an sync from the remote to the local created datastore:

```
proxmox-backup-manager pull s3store backups test2

pull datastore 'test2' from 's3store/backups'
----
Syncing datastore 'backups', namespace 'Root' into datastore 'test2', namespace 'Root'
Created namespace Root
found 2 groups to sync (out of 2 total)
sync snapshot ct/104/2024-08-20T08:27:02Z
sync archive pct.conf.blob
sync archive root.pxar.didx
[..]
pull datastore 'test2' end
TASK OK
```

Anyone who feels like testing this is welcome!

