### PR TITLE
GC: compare checksums of index files, cleanup

### DIFF
--- a/cmd/garbagecollector/main.go
+++ b/cmd/garbagecollector/main.go
@@ -6,19 +6,39 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"flag"
+	"fmt"
+	"github.com/juju/clock"
+	"github.com/juju/mutex/v2"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 	"io"
 	"os"
 	"strings"
 	"time"
 	"tizbac/pmoxs3backuproxy/internal/s3backuplog"
 	"tizbac/pmoxs3backuproxy/internal/s3pmoxcommon"
-
-	"github.com/juju/clock"
-	"github.com/juju/mutex/v2"
-	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
 )
+
+func compareSum(csum []byte, index []byte, metadatasum string) error {
+	fileChecksum := hex.EncodeToString(csum)
+	shaSum := sha256.Sum256(index)
+	checksum := hex.EncodeToString(shaSum[:])
+
+	if fileChecksum != checksum || fileChecksum != metadatasum {
+		return errors.New(
+			fmt.Sprintf(
+				"Corrupted index file: Checksum in index [%s] or metadata sum [%s] does not match calculated checksum [%s]",
+				fileChecksum,
+				metadatasum,
+				checksum,
+			),
+		)
+	}
+
+	return nil
+}
 
 func main() {
 	endpointFlag := flag.String("endpoint", "", "S3 Endpoint without https/http , host:port")
@@ -139,7 +159,11 @@ func main() {
 		s3backuplog.ErrorPrint("Failed to remove " + e.ObjectName + ", error: " + e.Err.Error())
 	}
 	//Phase 3 Mark Used chunks
-	for object := range minioClient.ListObjects(ctx, *bucketFlag, minio.ListObjectsOptions{Recursive: true, Prefix: "backups/"}) {
+	for object := range minioClient.ListObjects(ctx, *bucketFlag, minio.ListObjectsOptions{
+		Recursive:    true,
+		Prefix:       "backups/",
+		WithMetadata: true,
+	}) {
 		if strings.HasSuffix(object.Key, ".fidx") {
 			s3backuplog.InfoPrint("Processing fixed index: %s", object.Key)
 			o, err := minioClient.GetObject(ctx, *bucketFlag, object.Key, minio.GetObjectOptions{})
@@ -159,6 +183,13 @@ func main() {
 				os.Exit(1)
 				return
 			}
+
+			if csumerr := compareSum(data[32:64], data[4096:], object.UserMetadata["X-Amz-Meta-Csum"]); csumerr != nil {
+				s3backuplog.ErrorPrint("%s", csumerr.Error())
+				os.Exit(1)
+				return
+			}
+
 			data = data[4096:]
 			if len(data)%32 != 0 {
 				s3backuplog.ErrorPrint("Error examining object %s: Data after header length is not 32 bytes aligned", object.Key)
@@ -193,6 +224,13 @@ func main() {
 				os.Exit(1)
 				return
 			}
+
+			if csumerr := compareSum(data[32:64], data[4096:], object.UserMetadata["X-Amz-Meta-Csum"]); csumerr != nil {
+				s3backuplog.ErrorPrint("%s", csumerr.Error())
+				os.Exit(1)
+				return
+			}
+
 			reader := bytes.NewReader(data[4096:])
 			var offset int64 = 0
 			for {


### PR DESCRIPTION
may make sense to check for corrupted index files during GC, too.

remove some non-required returns after os.Exit